### PR TITLE
Fix ordering in mergeSet

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -126,6 +126,23 @@ def test_sexp_10 : IO Bool :=
        [ "(a b c d)" ])
     (Sexp.example.prettyPrint 10)
 
+def print_nested_choice (w : Nat) : String :=
+  let d := (Doc.concat
+   ((Doc.choice (Doc.text " ") (Doc.newline " ")))
+       (Doc.choice
+         (Doc.text "bc")
+         (Doc.concat
+           (Doc.newline " ")
+           (Doc.concat (Doc.choice (Doc.text "b") (Doc.newline " ")) (Doc.text "c")))))
+  Doc.prettyPrint (χ := DefaultCost) d 0 w
+
+
+def test_nested_choice : IO Bool :=
+  assertEq
+    (String.intercalate "\n"
+       [ " bc" ])
+    (print_nested_choice 10)
+
 def runTests (tests : List (String × IO Bool)) : IO Bool := do
   for (name, test) in tests do
     if ← test then
@@ -144,6 +161,7 @@ def main : IO UInt32 := do
     ("sexp 4", test_sexp_4),
     ("sexp 6", test_sexp_6),
     ("sexp 10", test_sexp_4),
+    ("nested choice 10", test_nested_choice)
   ]
   if ret then
     return 0

--- a/Pfmt.lean
+++ b/Pfmt.lean
@@ -128,8 +128,8 @@ into a new Pareto front with correct ordering.
 -/
 private def mergeSet [Cost χ] [DecidableRel (LE.le (α := χ))] (lhs rhs : List (Measure χ)) (acc : List (Measure χ) := []) : List (Measure χ) :=
   match h1:lhs, h2:rhs with
-  | [], _ => acc ++ rhs
-  | _, [] => acc ++ lhs
+  | [], _ => acc.reverse ++ rhs
+  | _, [] => acc.reverse ++ lhs
   | l :: ls, r :: rs =>
     if l ≤ r then
       mergeSet lhs rs acc
@@ -139,7 +139,7 @@ private def mergeSet [Cost χ] [DecidableRel (LE.le (α := χ))] (lhs rhs : List
       mergeSet ls rhs (l :: acc)
     else
       mergeSet lhs rs (r :: acc)
-termination_by mergeSet lhs rhs acc => lhs.length + rhs.length
+termination_by lhs.length + rhs.length
 
 /--
 Combine the results from two `MeasureSet`s.
@@ -396,7 +396,7 @@ instance : Cost DefaultCost where
     .text "let ident :=" ++
     (
      (.space ++ .text "func" ++ .flatten argD)
-     <|||> 
+     <|||>
      (.nest 2 (.nl ++ .text "func" ++ (.nest 2 argD)))
     )
   let out := Doc.prettyPrint DefaultCost (col := 0) (widthLimit := 20) d

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:4.4.0
+leanprover/lean4:v4.17.0-rc1


### PR DESCRIPTION
Change `mergeSet` so it aligns with `merge` from https://github.com/sorawee/pretty-expressive-ocaml/blob/main/lib/printer.ml.
This fixes a bug where nested choice documents were not rendered optimally.